### PR TITLE
THREE included from npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var THREE = require('three')
 var flatten = require('flatten-vertex-data')
 
 module.exports.attr = setAttribute

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/mattdesl"
   },
   "dependencies": {
+    "three": "^0.79.0",
     "flatten-vertex-data": "^1.0.0"
   },
   "devDependencies": {
@@ -20,7 +21,6 @@
     "primitive-quad": "^1.0.1",
     "primitive-sphere": "^2.0.0",
     "primitive-torus": "^1.0.4",
-    "three": "^0.73.0",
     "three-orbit-viewer": "^69.3.0",
     "uglify-js": "^2.6.1"
   },


### PR DESCRIPTION
I added requiring THREE.js from npm. I think it will be easier to connect the library. A lot of developers builds projects with build tools such as webpack. And this tools works very good with npm modules.
